### PR TITLE
fix(list-block): List Grouping

### DIFF
--- a/includes/blocks/converters/class-list-converter.php
+++ b/includes/blocks/converters/class-list-converter.php
@@ -24,44 +24,137 @@ class List_Converter extends Abstract_Block_Converter {
 	 */
 	public function supports( $block ) {
 		$type = $block['type'] ?? '';
-		return in_array( $type, [ 'bulleted_list_item', 'numbered_list_item' ], true );
+		// Support both individual list items and grouped lists.
+		return in_array( $type, [ 'bulleted_list_item', 'numbered_list_item' ], true ) ||
+			( isset( $block['is_grouped'] ) && $block['is_grouped'] );
 	}
 
 	/**
-	 * Convert Notion list item block to Gutenberg list.
+	 * Convert Notion list item block(s) to Gutenberg list.
 	 *
-	 * @param array $block Notion block object.
+	 * Handles both:
+	 * - Grouped lists (multiple consecutive list items)
+	 * - Individual list items (for nested children)
+	 *
+	 * @param array $block Notion block object or grouped list.
 	 * @param array $context Additional context.
 	 * @return string Gutenberg block HTML.
 	 */
 	public function convert( $block, $context = [] ) {
-		$type       = $block['type'] ?? '';
-		$block_data = $block[ $type ] ?? [];
-		$rich_text  = $block_data['rich_text'] ?? [];
-		$color      = $block_data['color'] ?? 'default';
-
-		$content = $this->rich_text_to_html( $rich_text );
-
-		$list_type   = 'bulleted_list_item' === $type ? 'ul' : 'ol';
-		$block_name  = 'bulleted_list_item' === $type ? 'core/list' : 'core/list';
-		
-		$html = '<' . $list_type . '><li>' . $content;
-
-		// Process nested children.
-		if ( ! empty( $block['children'] ) ) {
-			$html .= $this->process_children( $block['children'], $context );
+		// Check if this is a grouped list.
+		if ( isset( $block['is_grouped'] ) && $block['is_grouped'] ) {
+			return $this->convert_grouped_list( $block, $context );
 		}
 
-		$html .= '</li></' . $list_type . '>';
+		// Individual list item (used for nested children).
+		return $this->convert_single_item( $block, $context );
+	}
+
+	/**
+	 * Convert a grouped list (multiple list items).
+	 *
+	 * @param array $grouped_block Grouped list block.
+	 * @param array $context Additional context.
+	 * @return string Gutenberg block HTML.
+	 */
+	private function convert_grouped_list( $grouped_block, $context = [] ) {
+		$type       = $grouped_block['type'] ?? '';
+		$list_items = $grouped_block['list_items'] ?? [];
+
+		if ( empty( $list_items ) ) {
+			return '';
+		}
+
+		$is_ordered = 'numbered_list_item' === $type;
+		$list_tag   = $is_ordered ? 'ol' : 'ul';
+		$block_name = 'core/list';
+
+		// Build the list HTML.
+		$html = '<' . $list_tag . '>';
+
+		foreach ( $list_items as $item ) {
+			$html .= $this->convert_list_item_content( $item, $context );
+		}
+
+		$html .= '</' . $list_tag . '>';
+
+		// Get color from first item (if any have color, use it for the whole list).
+		$color = '';
+		foreach ( $list_items as $item ) {
+			$item_type = $item['type'] ?? '';
+			$item_data = $item[ $item_type ] ?? [];
+			$item_color = $item_data['color'] ?? 'default';
+			if ( 'default' !== $item_color ) {
+				$color = $item_color;
+				break;
+			}
+		}
+
+		// Prepare attributes.
+		$attributes = [
+			'ordered' => $is_ordered,
+		];
+
+		if ( 'default' !== $color && ! empty( $color ) ) {
+			$attributes['className'] = $this->get_color_class( $color );
+		}
+
+		return $this->wrap_gutenberg_block( $block_name, $html, $attributes );
+	}
+
+	/**
+	 * Convert a single list item (for nested children).
+	 *
+	 * @param array $block Notion list item block.
+	 * @param array $context Additional context.
+	 * @return string List item HTML (without wrapping list tags).
+	 */
+	private function convert_single_item( $block, $context = [] ) {
+		$type      = $block['type'] ?? '';
+		$is_ordered = 'numbered_list_item' === $type;
+		$list_tag  = $is_ordered ? 'ol' : 'ul';
+
+		$html = '<' . $list_tag . '>';
+		$html .= $this->convert_list_item_content( $block, $context );
+		$html .= '</' . $list_tag . '>';
+
+		$block_data = $block[ $type ] ?? [];
+		$color      = $block_data['color'] ?? 'default';
 
 		$attributes = [
-			'ordered' => 'numbered_list_item' === $type,
+			'ordered' => $is_ordered,
 		];
 
 		if ( 'default' !== $color ) {
 			$attributes['className'] = $this->get_color_class( $color );
 		}
 
-		return $this->wrap_gutenberg_block( $block_name, $html, $attributes );
+		return $this->wrap_gutenberg_block( 'core/list', $html, $attributes );
+	}
+
+	/**
+	 * Convert the content of a single list item.
+	 *
+	 * @param array $item Notion list item block.
+	 * @param array $context Additional context.
+	 * @return string List item HTML.
+	 */
+	private function convert_list_item_content( $item, $context = [] ) {
+		$type       = $item['type'] ?? '';
+		$block_data = $item[ $type ] ?? [];
+		$rich_text  = $block_data['rich_text'] ?? [];
+
+		$content = $this->rich_text_to_html( $rich_text );
+
+		$html = '<li>' . $content;
+
+		// Process nested children (e.g., nested lists, paragraphs).
+		if ( ! empty( $item['children'] ) ) {
+			$html .= $this->process_children( $item['children'], $context );
+		}
+
+		$html .= '</li>';
+
+		return $html;
 	}
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Each Notion list item (bulleted or numbered) was creating its own `<ul>` or `<ol>` element with only one `<li>` item, resulting in visually broken lists in WordPress.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Issue
Fixes the issue where Notion list items were being converted to separate individual lists in WordPress instead of being grouped together as a single list.

**Cause:** Notion API returns each list item as a separate block, but Gutenberg expects consecutive list items to be grouped in a single list block.

## Changes Made
<!-- Provide a detailed list of changes made in this PR -->

**Added `group_associated_items()` method** in `Block_Registry` class to detect and group consecutive list items of the same type before conversion.

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Tested locally in WordPress environment
- [x] Tested with Notion API integration
- [x] Tested import functionality
- [ ] Tested authentication flow
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Checklist
<!-- Ensure all items are completed before submitting -->

- [x] My code follows the coding standards and passes all tests.
- [ ] I have added/modified tests covering my changes.
- [x] I have added a thorough explanation for my changes.
