### PR TITLE
fix(file-block): update conversion method to handle proper conversion

### DIFF
--- a/includes/blocks/converters/class-file-converter.php
+++ b/includes/blocks/converters/class-file-converter.php
@@ -27,7 +27,7 @@ class File_Converter extends Abstract_Block_Converter {
 	}
 
 	/**
-	 * Convert Notion paragraph block to Gutenberg paragraph.
+	 * Convert Notion file block to Gutenberg file block.
 	 *
 	 * @param array $block Notion block object.
 	 * @param array $context Additional context.
@@ -50,7 +50,16 @@ class File_Converter extends Abstract_Block_Converter {
 		}
 
 		$html = '<div class="wp-block-file">';
-		$html .= '<a href="' . esc_url( $url ) . '" download>' . esc_html( $name ) . '</a>';
+		$html .= sprintf(
+			'<a href="%s">%s</a>',
+			$url,
+			esc_html( $name )
+		);
+		$html .= sprintf(
+			'<a href="%s" class="wp-block-file__button wp-element-button" download="">%s</a>',
+			rawurlencode( $url ),
+			__( 'Download', 'notion2wp' )
+		);
 		$html .= '</div>';
 
 		return $this->wrap_gutenberg_block( 'core/file', $html, [ 'href' => $url ] );


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fixed file block conversion to generate proper Gutenberg-compatible HTML structure with URL encoding, preventing double/triple escaping of special characters in file URLs.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes URL encoding issue where ampersands in AWS S3 signed URLs were being triple-encoded (`u0026amp;` instead of `&`), breaking file downloads in WordPress.

## Changes Made
<!-- Provide a detailed list of changes made in this PR -->

- Removed `esc_url()` wrapper that caused over-escaping
  - Pass raw URLs to HTML (WordPress handles escaping during render)
  - Pass raw URLs to block attributes (wp_json_encode handles JSON encoding)
- Added text link with filename
  - Added download button with "Download" label.
  - Applied proper CSS classes (`wp-block-file__button`, `wp-element-button`)

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Tested locally in WordPress environment
- [x] Tested with Notion API integration
- [x] Tested import functionality
- [ ] Tested authentication flow
- [ ] All existing tests pass
- [ ] Added new tests for new functionality

## Checklist
<!-- Ensure all items are completed before submitting -->

- [x] My code follows the coding standards and passes all tests.
- [ ] I have added/modified tests covering my changes.
- [x] I have added a thorough explanation for my changes.
