### PR TITLE
feat: Secure Integration Token

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,9 +93,8 @@ We take the security of Notion2WP seriously. If you have discovered a security v
 ### Current Security Measures
 
 1. **Authentication**
-   - Secure token storage in WordPress database
-   - WordPress nonce verification for all AJAX requests
-   - Capability checks for admin operations
+   - Integration token stored in its own dedicated option (`notion2wp_integration_token`), not mixed into the general settings blob.
+   - Optional override: define `NOTION2WP_INTEGRATION_TOKEN` in `wp-config.php` to keep the token entirely off the database. When set, the admin UI treats the connection as read-only and refuses to overwrite the constant.
 
 2. **Data Handling**
    - Input sanitization using WordPress functions
@@ -114,9 +113,7 @@ We take the security of Notion2WP seriously. If you have discovered a security v
 
 ### Known Limitations
 
-- Integration tokens are stored in WordPress database (encrypted via WordPress)
-- Requires WordPress admin access for configuration
-- Depends on WordPress security measures
+- WordPress has no plugin isolation; secrets are accessible to any plugin in the same PHP process. See the threat model above.
 
 ## Disclosure Policy
 

--- a/includes/admin/class-rest-api.php
+++ b/includes/admin/class-rest-api.php
@@ -267,10 +267,7 @@ class Rest_API {
 	public static function get_settings( $request ) {
 		$settings = Settings::get_settings();
 
-		// Remove sensitive data from response.
-		unset( $settings['client_secret'] );
-		unset( $settings['access_token'] );
-		unset( $settings['refresh_token'] );
+		unset( $settings['integration_token'] );
 
 		return new WP_REST_Response( $settings, 200 );
 	}
@@ -287,7 +284,6 @@ class Rest_API {
 
 		// Merge with current settings, preserving auth data.
 		$auth_keys = [
-			'integration_token',
 			'bot_id',
 			'owner',
 			'duplicated_template_id',

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -7,6 +7,8 @@
 
 namespace Notion2WP\Admin;
 
+use Notion2WP\Auth\Auth;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -31,7 +33,6 @@ class Settings {
 	 */
 	private static $default_settings = [
 		// Internal Integration Settings.
-		'integration_token'      => '',
 		'bot_id'                 => '',
 		'owner'                  => null,
 		'token_obtained_at'      => null,
@@ -205,7 +206,6 @@ class Settings {
 		$settings = self::get_settings();
 
 		return [
-			'integration_token' => $settings['integration_token'],
 			'bot_id'            => $settings['bot_id'],
 			'owner'             => $settings['owner'],
 			'token_obtained_at' => $settings['token_obtained_at'],
@@ -283,6 +283,7 @@ class Settings {
 
 		delete_option( self::SETTINGS_OPTION );
 		delete_option( self::SETUP_GUIDE_OPTION );
+		delete_option( Auth::TOKEN_OPTION );
 	}
 }
 

--- a/includes/auth/class-auth.php
+++ b/includes/auth/class-auth.php
@@ -8,6 +8,7 @@
 namespace Notion2WP\Auth;
 
 use Notion2WP\Admin\Settings;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,6 +35,16 @@ class Auth {
 	const API_VERSION = '2025-09-03';
 
 	/**
+	 * Option name that stores the integration token.
+	 */
+	const TOKEN_OPTION = 'notion2wp_integration_token';
+
+	/**
+	 * Constant that, when defined in wp-config.php, takes precedence over any value in the database.
+	 */
+	const TOKEN_CONSTANT = 'NOTION2WP_INTEGRATION_TOKEN';
+
+	/**
 	 * Save integration token.
 	 *
 	 * @param string $integration_token The Notion integration token.
@@ -47,15 +58,23 @@ class Auth {
 			);
 		}
 
+		if ( self::is_token_managed_by_constant() ) {
+			return new WP_Error(
+				'notion2wp_token_locked',
+				__( 'Integration token is configured via the NOTION2WP_INTEGRATION_TOKEN constant in wp-config.php and cannot be changed from the admin UI.', 'notion2wp' )
+			);
+		}
+
 		$test_result = self::verify_token( $integration_token );
 
 		if ( is_wp_error( $test_result ) ) {
 			return $test_result;
 		}
 
-		// Store the token and workspace info.
-		$settings = Settings::get_settings();
-		$settings['integration_token'] = $integration_token;
+		update_option( self::TOKEN_OPTION, $integration_token, false );
+		self::drop_legacy_token();
+
+		$settings                      = Settings::get_settings();
 		$settings['bot_id']            = $test_result['bot_id'] ?? '';
 		$settings['token_obtained_at'] = time();
 
@@ -119,13 +138,12 @@ class Auth {
 	}
 
 	/**
-	 * Check if we have a valid integration token.
+	 * Check if we have an integration token configured.
 	 *
 	 * @return bool
 	 */
 	public static function has_valid_token() {
-		$settings = Settings::get_settings();
-		return ! empty( $settings['integration_token'] );
+		return '' !== (string) self::get_integration_token();
 	}
 
 	/**
@@ -134,8 +152,22 @@ class Auth {
 	 * @return string|null
 	 */
 	public static function get_integration_token() {
-		$settings = Settings::get_settings();
-		return $settings['integration_token'] ?? null;
+		if ( self::is_token_managed_by_constant() ) {
+			return (string) constant( self::TOKEN_CONSTANT );
+		}
+
+		$token = get_option( self::TOKEN_OPTION, '' );
+		if ( is_string( $token ) && '' !== $token ) {
+			return $token;
+		}
+
+		$legacy = self::drop_legacy_token();
+		if ( null !== $legacy ) {
+			update_option( self::TOKEN_OPTION, $legacy, false );
+			return $legacy;
+		}
+
+		return null;
 	}
 
 	/**
@@ -144,16 +176,27 @@ class Auth {
 	 * @return bool
 	 */
 	public static function revoke_token() {
-		$settings = Settings::get_settings();
+		delete_option( self::TOKEN_OPTION );
+		self::drop_legacy_token();
 
-		// Clear all integration-related settings.
-		unset( $settings['integration_token'] );
+		$settings = Settings::get_settings();
 		unset( $settings['bot_id'] );
 		unset( $settings['token_obtained_at'] );
 
 		Settings::update_settings( $settings, false );
 
 		return true;
+	}
+
+	/**
+	 * Whether the token is supplied via a wp-config.php constant.
+	 *
+	 * @return bool
+	 */
+	public static function is_token_managed_by_constant() {
+		return defined( self::TOKEN_CONSTANT )
+			&& is_string( constant( self::TOKEN_CONSTANT ) )
+			&& '' !== constant( self::TOKEN_CONSTANT );
 	}
 
 	/**
@@ -165,16 +208,38 @@ class Auth {
 		$settings = Settings::get_settings();
 
 		$status = [
-			'connected'       => false,
-			'connection_date' => null,
+			'connected'           => false,
+			'connection_date'     => null,
+			'managed_by_constant' => self::is_token_managed_by_constant(),
 		];
 
-		if ( ! empty( $settings['integration_token'] ) ) {
+		if ( self::has_valid_token() ) {
 			$status['connected']       = true;
 			$status['connection_date'] = ! empty( $settings['token_obtained_at'] ) ?
 				date_i18n( get_option( 'date_format' ), $settings['token_obtained_at'] ) : null;
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Remove a legacy plaintext token from the settings blob.
+	 *
+	 * Returns the legacy value (if any) so callers can migrate it into the dedicated option.
+	 *
+	 * @return string|null
+	 */
+	private static function drop_legacy_token() {
+		$settings = get_option( Settings::SETTINGS_OPTION, [] );
+
+		if ( ! is_array( $settings ) || empty( $settings['integration_token'] ) ) {
+			return null;
+		}
+
+		$legacy = (string) $settings['integration_token'];
+		unset( $settings['integration_token'] );
+		update_option( Settings::SETTINGS_OPTION, $settings );
+
+		return $legacy;
 	}
 }

--- a/src/components/Connection.jsx
+++ b/src/components/Connection.jsx
@@ -255,26 +255,41 @@ const Connection = () => {
 									<span className="notion2wp-badge__dot" />
 									{ __( 'Connected', 'notion2wp' ) }
 								</span>
-								{ status.connection_date && (
+								{ status.managed_by_constant && (
+									<span className="notion2wp-badge notion2wp-badge--info">
+										{ __( 'Managed via wp-config.php', 'notion2wp' ) }
+									</span>
+								) }
+								{ status.connection_date && ! status.managed_by_constant && (
 									<span className="notion2wp-connection__connected-date">
 										{ status.connection_date }
 									</span>
 								) }
 							</div>
-							<Button
-								variant="secondary"
-								isDestructive
-								size="small"
-								onClick={ () => setShowDisconnectConfirm( true ) }
-								isBusy={ loading }
-								disabled={ loading }
-							>
-								{ loading
-									? __( 'Disconnecting...', 'notion2wp' )
-									: __( 'Disconnect', 'notion2wp' )
-								}
-							</Button>
+							{ ! status.managed_by_constant && (
+								<Button
+									variant="secondary"
+									isDestructive
+									size="small"
+									onClick={ () => setShowDisconnectConfirm( true ) }
+									isBusy={ loading }
+									disabled={ loading }
+								>
+									{ loading
+										? __( 'Disconnecting...', 'notion2wp' )
+										: __( 'Disconnect', 'notion2wp' )
+									}
+								</Button>
+							) }
 						</div>
+						{ status.managed_by_constant && (
+							<p className="notion2wp-connection__constant-note">
+								{ __(
+									'The integration token is supplied by the NOTION2WP_INTEGRATION_TOKEN constant in your wp-config.php. To change or remove the token, edit the constant on the server.',
+									'notion2wp',
+								) }
+							</p>
+						) }
 					</CardBody>
 				</Card>
 			) : (

--- a/src/components/SetupGuide.jsx
+++ b/src/components/SetupGuide.jsx
@@ -164,6 +164,18 @@ const SetupGuide = ( { onFinish } ) => {
 							) }
 						</p>
 					</div>
+					<div className="notion2wp-guide__callout notion2wp-guide__callout--info">
+						<strong>{ __( 'Advanced: keep the token out of the database', 'notion2wp' ) }</strong>
+						<p>
+							{ __(
+								'For hardened deployments, you can define the token in wp-config.php instead of pasting it into the admin UI. When this constant is set, Notion2WP reads from it and never writes the token to the database.',
+								'notion2wp',
+							) }
+						</p>
+						<pre className="notion2wp-guide__code">
+							<code>{ 'define( \'NOTION2WP_INTEGRATION_TOKEN\', \'secret_xxxxxxxxxxxxxxxx\' );' }</code>
+						</pre>
+					</div>
 				</div>
 			),
 		},

--- a/src/style.scss
+++ b/src/style.scss
@@ -585,6 +585,13 @@ $duration-slow:   0.4s;
 		color: $color-error;
 	}
 
+	&--info {
+		background: $color-surface-hover;
+		color: $color-text-secondary;
+		font-family: $font-mono;
+		font-size: 12px;
+	}
+
 	&__dot {
 		width: 6px;
 		height: 6px;
@@ -870,6 +877,15 @@ $duration-slow:   0.4s;
 		color: $color-text-tertiary;
 	}
 
+	&__constant-note {
+		margin: $space-md 0 0;
+		padding-top: $space-md;
+		border-top: 1px solid $color-border;
+		font-size: 13px;
+		line-height: 1.5;
+		color: $color-text-secondary;
+	}
+
 	// Token input
 	&__token-input {
 		font-family: $font-mono;
@@ -1115,6 +1131,25 @@ $duration-slow:   0.4s;
 		p {
 			margin: $space-sm 0 0;
 			font-size: inherit;
+		}
+	}
+
+	&__code {
+		margin: $space-sm 0 0;
+		padding: $space-sm $space-md;
+		background: $color-text-primary;
+		color: #e5e5ea;
+		border-radius: $radius-sm;
+		font-family: $font-mono;
+		font-size: 12px;
+		line-height: 1.5;
+		overflow-x: auto;
+
+		code {
+			background: none;
+			color: inherit;
+			font-size: inherit;
+			padding: 0;
 		}
 	}
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -786,7 +786,7 @@ $duration-slow:   0.4s;
 			color: $color-text-secondary;
 			font-size: 15px;
 			line-height: 1.6;
-			max-width: 420px;
+			max-width: 600px;
 			margin: 0 auto;
 		}
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -20,6 +20,7 @@ function notion2wp_uninstall() {
 	// Remove plugin options.
 	delete_option( 'notion2wp_settings' );
 	delete_option( 'notion2wp_allowed_roles' );
+	delete_option( 'notion2wp_integration_token' );
 
 	// Remove custom capability from all roles.
 	$roles = wp_roles();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Hardens storage of the Notion integration token by moving it out of the general settings blob into a dedicated option, and adds a wp-config.php constant override (NOTION2WP_INTEGRATION_TOKEN) so security-conscious operators can keep the token entirely off the database. Also fixes a bug where GET /notion2wp/v1/settings was returning the token in its response. Follows the storage pattern used by WooCommerce, Jetpack, Akismet, Wordfence, and WP Mail SMTP.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Issue
<!-- Link to the issue this PR addresses, if applicable -->
N/A — opportunistic hardening triggered by audit.

## Changes Made
<!-- Provide a detailed list of changes made in this PR -->

- The integration token now lives in its own option (notion2wp_integration_token) instead of being embedded inside notion2wp_settings['integration_token'].
- when NOTION2WP_INTEGRATION_TOKEN defined in wp-config.php, the plugin reads the token from the constant and refuses to write to the database.
- GET /notion2wp/v1/settings now defensively unsets integration_token from the response (belt-and-suspenders since the token is no longer written there).
- SECURITY.md rewrite. Replaces the inaccurate claim that tokens were "encrypted via WordPress".

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Tested locally in WordPress environment
- [x] Tested with Notion API integration
- [x] Tested import functionality
- [x] Tested authentication flow
- [x] All existing tests pass
- [ ] Added new tests for new functionality

## Checklist
<!-- Ensure all items are completed before submitting -->

- [x] My code follows the coding standards and passes all tests.
- [ ] I have added/modified tests covering my changes.
- [x] I have added a thorough explanation for my changes.

## Additional Notes
<!-- Add any additional context or notes for reviewers -->
Given WordPress's fundamental lack of plugin isolation — any active plugin can call `get_option()` or `Auth::get_integration_token()` a at-rest encryption approach defended against a narrow DB-only-leak scenario while adding real complexity (two crypto codepaths, silent failure on salt rotation, concurrency considerations in migration).

## Reviewer Notes
<!-- Space for reviewers to add comments -->
